### PR TITLE
Add controllers and endpoints to add adopters and adopt cats

### DIFF
--- a/models/cat.model.js
+++ b/models/cat.model.js
@@ -1,5 +1,4 @@
 const mongoose = require("mongoose");
-const { number } = require("yup");
 
 const catSchema = new mongoose.Schema(
   {
@@ -52,7 +51,17 @@ const catSchema = new mongoose.Schema(
     },
     image: {
       type: String,
-      required: true, // Puedes establecerlo como requerido si todas las cuentas deben tener una imagen
+      required: true,
+    },
+    adopterId: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "userRegistration",
+      },
+    ],
+    adopted: {
+      type: Boolean,
+      default: false,
     },
   },
   {

--- a/routes/cats.routes.js
+++ b/routes/cats.routes.js
@@ -2,9 +2,12 @@ const express = require("express");
 const router = express.Router();
 const {
   createCat,
-  getCats,
+  getUserCats,
   updateCat,
   deleteCat,
+  addAdopter,
+  getAllCats,
+  adoptCat,
 } = require("../controllers/catsController");
 const authRequired = require("../middlewares/validateToken");
 
@@ -12,12 +15,18 @@ const authRequired = require("../middlewares/validateToken");
 router.post("/cats", authRequired, createCat);
 
 // Ruta: obtener todos los gatos
-router.get("/cats", authRequired, getCats);
+router.get("/cats", authRequired, getAllCats); // Ruta para obtener todos los gatos
+
+// Ruta: Obtener los gatos del usuario autenticado
+router.get("/user-cats", authRequired, getUserCats);
 
 // Ruta: actualizar un gato por ID
 router.put("/cats/:id", authRequired, updateCat);
 
 // Ruta: eliminar un gato por ID
 router.delete("/cats/:id", authRequired, deleteCat);
+
+// Ruta: marcar un gato como adoptado
+router.put("/cats/:id/adopted", authRequired, adoptCat);
 
 module.exports = router;


### PR DESCRIPTION
**Este commit introduce dos nuevos controladores, addAdopter y adoptCat, junto con sus correspondientes endpoints, para facilitar el proceso de añadir adoptantes a gatos y adoptar gatos por parte de los usuarios.**

**Controlador addAdopter:**
El controlador addAdopter maneja la adición de adoptantes a un gato específico. Toma como entrada el ID del gato y el ID del adoptante, y añade al adoptante a la lista de adoptantes del gato.

**Controlador adoptCat:**
El controlador adoptCat es responsable de marcar a un gato como adoptado y asociarlo con un adoptante. Toma como entrada el ID del gato, el ID del adoptante y el ID del usuario. Si se proporciona el ID del adoptante, marca al gato como adoptado y añade al adoptante a la lista de adoptantes del gato. De lo contrario, devuelve un código de estado 400 indicando que se requiere el ID del adoptante.

Estos controladores y endpoints mejoran la funcionalidad de la aplicación al permitir a los usuarios interactuar con los gatos a través de procesos de adopción.

[ Miguel Ortiz ]-[ Junior Back-End Developer ]