### PR TITLE
feat: Add endpoint to remove adopter from cat's adopter list

### DIFF
--- a/controllers/catsController.js
+++ b/controllers/catsController.js
@@ -130,7 +130,36 @@ const updateCatOwner = async (req, res) => {
     res.status(200).json(updatedCat);
   } catch (error) {
     console.error("Error al actualizar el propietario del gato:", error);
-    res.status(500).json({ message: "Error al actualizar el propietario del gato", error });
+    res
+      .status(500)
+      .json({ message: "Error al actualizar el propietario del gato", error });
+  }
+};
+
+const removeAdopter = async (req, res) => {
+  const { id } = req.params; // ID del gato
+  const userId = req.user.id; // ID del usuario en sesión
+
+  try {
+    const cat = await Cat.findById(id);
+    if (!cat) {
+      return res.status(404).json({ message: "Gato no encontrado" });
+    }
+
+    const adopterIndex = cat.adopterId.indexOf(userId);
+    if (adopterIndex > -1) {
+      cat.adopterId.splice(adopterIndex, 1);
+      await cat.save();
+    } else {
+      return res
+        .status(400)
+        .json({ message: "El usuario no es adoptante de este gato" });
+    }
+
+    res.status(200).json(cat);
+  } catch (error) {
+    console.error("Error al eliminar adoptante:", error);
+    res.status(500).json({ message: "Error al eliminar adoptante", error });
   }
 };
 
@@ -142,4 +171,5 @@ module.exports = {
   addAdopter,
   adoptCat,
   updateCatOwner,
+  removeAdopter, // Añadido nuevo método
 };

--- a/routes/cats.routes.js
+++ b/routes/cats.routes.js
@@ -28,4 +28,7 @@ router.put("/cats/:id/adopted", authRequired, adoptCat);
 //Ruta: actualización ownerID
 router.put("/cats/:id/update-owner", authRequired, updateCatOwner);
 
+//Ruta: remover el id del usuario en cesion del arrai de un gatito
+router.delete("/cats/:id/remove-adopter", authMiddleware, removeAdopter);
+
 module.exports = router;


### PR DESCRIPTION
**Se ha añadido un nuevo endpoint en el controlador de gatitos para permitir la eliminación de un adoptante de la lista de adoptantes de un gato. Este cambio permite que los usuarios puedan desasociarse como adoptantes de un gato específico.**

Cambios Realizados
Controlador CatsControllers:

Se añadió el método removeAdopter para eliminar a un usuario de la lista de adoptantes (adopterId) de un gato.
Rutas:

Se actualizó el archivo de rutas para incluir el nuevo endpoint que permite la eliminación de un adoptante de un gato.
Implementación
Controlador CatsControllers:

Se obtiene el id del gato y el userId del usuario en sesión.
Se busca el gato por su id. Si no se encuentra, se devuelve un mensaje de error.
Se verifica si el userId está en la lista de adoptantes del gato. Si está, se elimina de la lista y se guarda el gato actualizado. Si no está, se devuelve un mensaje de error.
Se devuelve el gato actualizado en la respuesta.
Rutas:

Se define una nueva ruta DELETE para eliminar a un adoptante de un gato.
La ruta se asegura de que solo usuarios autenticados puedan acceder a ella mediante un middleware de validación de token.